### PR TITLE
remove unnecesary endif

### DIFF
--- a/textgrid_revisor.praat
+++ b/textgrid_revisor.praat
@@ -34,7 +34,7 @@ for ifile to number_files
 				Save as text file: "'directory$''soundname$'.TextGrid"
 			endif
 			lastsound$ = soundname$
-		endif
+		
 		selectObject: "Sound 'soundname$'"
 		plusObject: "TextGrid 'soundname$'"
 		Remove


### PR DESCRIPTION
I could be wrong, but when reviewing a script that I had adapted from here I noticed there's one more endif than there are ifs. I think this might be a mistake so I thought I'd make note of it here so it doesn't give you any future trouble (: