### PR TITLE
Fix sound selection by using soundID

### DIFF
--- a/amplitude_measurerv2.praat
+++ b/amplitude_measurerv2.praat
@@ -27,8 +27,10 @@ for j from 1 to number_files
         select Strings list
         filename$ = Get string... 'j'
         Read from file... 'directory$''filename$'
-        soundname$ = selected$ ("Sound")
-	select Sound soundname$
+        
+        ##edit, using the sound name wasn't working properly
+        soundID = selected("Sound")
+	selectObject: soundID
 	do ("To Intensity...", 100, 0, "yes")
 	min = do ("Get minimum...", 0, 0, "Parabolic")
 	max = do ("Get maximum...", 0, 0, "Parabolic")


### PR DESCRIPTION
the script was refusing to select the sound by name, not sure why. A lot of people online seem to be having issues with indexing in praat so I'm wondering if maybe an update caused a change in how it works somewhere along the way. This way seems to index by number and then that object is selected which fixed the issue for me. I'll make a fork in case it's helpful